### PR TITLE
Apply a factory pattern to the create contact functions in population.py

### DIFF
--- a/covasim/population.py
+++ b/covasim/population.py
@@ -400,7 +400,7 @@ class HybridContacts:
         return contacts_list, layer_keys, clusters
 
 
-class ContactFactory():
+class ContactFactory(metaclass=ABCMeta):
     @abstractmethod
     def create_contacts(pop_size,ages,contacts, overshoot=1.2, dispersion=None,school_ages=None,work_ages=None):
         pass

--- a/covasim/population.py
+++ b/covasim/population.py
@@ -3,6 +3,7 @@ Defines functions for making the population.
 '''
 
 #%% Imports
+from abc import abstractmethod
 import numpy as np # Needed for a few things not provided by pl
 import sciris as sc
 from collections import defaultdict
@@ -25,7 +26,6 @@ def make_people(sim, popdict=None, save_pop=False, popfile=None, die=True, reset
     '''
     Make the actual people for the simulation. Usually called via sim.initialize(),
     but can be called directly by the user.
-
     Args:
         sim      (Sim)  : the simulation object; population parameters are taken from the sim object
         popdict  (dict) : if supplied, use this population dictionary instead of generating a new one
@@ -35,7 +35,6 @@ def make_people(sim, popdict=None, save_pop=False, popfile=None, die=True, reset
         reset    (bool) : whether to force population creation even if self.popdict/self.people exists
         verbose  (bool) : level of detail to print
         kwargs   (dict) : passed to make_randpop() or make_synthpop()
-
     Returns:
         people (People): people
     '''
@@ -107,22 +106,18 @@ def make_people(sim, popdict=None, save_pop=False, popfile=None, die=True, reset
 def make_randpop(sim, use_age_data=True, use_household_data=True, sex_ratio=0.5, microstructure=False):
     '''
     Make a random population, with contacts.
-
     This function returns a "popdict" dictionary, which has the following (required) keys:
-
         - uid: an array of (usually consecutive) integers of length N, uniquely identifying each agent
         - age: an array of floats of length N, the age in years of each agent
         - sex: an array of integers of length N (not currently used, so does not have to be binary)
         - contacts: list of length N listing the contacts; see make_random_contacts() for details
         - layer_keys: a list of strings representing the different contact layers in the population; see make_random_contacts() for details
-
     Args:
         sim (Sim): the simulation object
         use_age_data (bool): whether to use location-specific age data
         use_household_data (bool): whether to use location-specific household size data
         sex_ratio (float): proportion of the population that is male (not currently used)
         microstructure (bool): whether or not to use the microstructuring algorithm to group contacts
-
     Returns:
         popdict (dict): a dictionary representing the population, with the following keys for a population of N agents with M contacts between them:
     '''
@@ -170,9 +165,9 @@ def make_randpop(sim, use_age_data=True, use_household_data=True, sex_ratio=0.5,
     popdict['sex'] = sexes
 
     # Actually create the contacts
-    if   microstructure == 'random':    contacts, layer_keys    = make_random_contacts(pop_size, sim['contacts'])
-    elif microstructure == 'clustered': contacts, layer_keys, _ = make_microstructured_contacts(pop_size, sim['contacts'])
-    elif microstructure == 'hybrid':    contacts, layer_keys, _ = make_hybrid_contacts(pop_size, ages, sim['contacts'])
+    if   microstructure == 'random':    contacts, layer_keys    = RamdonContactsFactory().create_contacts().make_random_contacts(pop_size, sim['contacts'])
+    elif microstructure == 'clustered': contacts, layer_keys, _ = MicrostructuredContactsFactory().create_contacts().make_microstructured_contacts(pop_size, sim['contacts'])
+    elif microstructure == 'hybrid':    contacts, layer_keys, _ = HybridContactsFactory().create_contacts().make_hybrid_contacts(pop_size, ages, sim['contacts'])
     else: # pragma: no cover
         errormsg = f'Microstructure type "{microstructure}" not found; choices are random, clustered, or hybrid'
         raise NotImplementedError(errormsg)
@@ -182,156 +177,19 @@ def make_randpop(sim, use_age_data=True, use_household_data=True, sex_ratio=0.5,
 
     return popdict
 
-
-def make_random_contacts(pop_size, contacts, overshoot=1.2, dispersion=None):
-    '''
-    Make random static contacts.
-
-    Args:
-        pop_size (int): number of agents to create contacts between (N)
-        contacts (dict): a dictionary with one entry per layer describing the average number of contacts per person for that layer
-        overshoot (float): to avoid needing to take multiple Poisson draws
-        dispersion (float): if not None, use a negative binomial distribution with this dispersion parameter instead of Poisson to make the contacts
-
-    Returns:
-        contacts_list (list): a list of length N, where each entry is a dictionary by layer, and each dictionary entry is the UIDs of the agent's contacts
-        layer_keys (list): a list of layer keys, which is the same as the keys of the input "contacts" dictionary
-    '''
-
-    # Preprocessing
-    pop_size = int(pop_size) # Number of people
-    contacts = sc.dcp(contacts)
-    layer_keys = list(contacts.keys())
-    contacts_list = []
-
-    # Precalculate contacts
-    n_across_layers = np.sum(list(contacts.values()))
-    n_all_contacts  = int(pop_size*n_across_layers*overshoot) # The overshoot is used so we won't run out of contacts if the Poisson draws happen to be higher than the expected value
-    all_contacts    = cvu.choose_r(max_n=pop_size, n=n_all_contacts) # Choose people at random
-    p_counts = {}
-    for lkey in layer_keys:
-        if dispersion is None:
-            p_count = cvu.n_poisson(contacts[lkey], pop_size) # Draw the number of Poisson contacts for this person
-        else:
-            p_count = cvu.n_neg_binomial(rate=contacts[lkey], dispersion=dispersion, n=pop_size) # Or, from a negative binomial
-        p_counts[lkey] = np.array((p_count/2.0).round(), dtype=cvd.default_int)
-
-    # Make contacts
-    count = 0
-    for p in range(pop_size):
-        contact_dict = {}
-        for lkey in layer_keys:
-            n_contacts = p_counts[lkey][p]
-            contact_dict[lkey] = all_contacts[count:count+n_contacts] # Assign people
-            count += n_contacts
-        contacts_list.append(contact_dict)
-
-    return contacts_list, layer_keys
-
-
-def make_microstructured_contacts(pop_size, contacts):
-    ''' Create microstructured contacts -- i.e. for households '''
-
-    # Preprocessing -- same as above
-    pop_size = int(pop_size) # Number of people
-    contacts = sc.dcp(contacts)
-    contacts.pop('c', None) # Remove community
-    layer_keys = list(contacts.keys())
-    contacts_list = [{c:[] for c in layer_keys} for p in range(pop_size)] # Pre-populate
-
-    for layer_name, cluster_size in contacts.items():
-
-        # Initialize
-        cluster_dict = dict() # Add dictionary for this layer
-        n_remaining = pop_size # Make clusters - each person belongs to one cluster
-        contacts_dict = defaultdict(set) # Use defaultdict of sets for convenience while initializing. Could probably change this as part of performance optimization
-
-        # Loop over the clusters
-        cluster_id = -1
-        while n_remaining > 0:
-            cluster_id += 1 # Assign cluster id
-            this_cluster =  cvu.poisson(cluster_size)  # Sample the cluster size
-            if this_cluster > n_remaining:
-                this_cluster = n_remaining
-
-            # Indices of people in this cluster
-            cluster_indices = (pop_size-n_remaining)+np.arange(this_cluster)
-            cluster_dict[cluster_id] = cluster_indices
-            for i in cluster_indices: # Add symmetric pairwise contacts in each cluster
-                for j in cluster_indices:
-                    if j > i:
-                        contacts_dict[i].add(j)
-
-            n_remaining -= this_cluster
-
-        for key in contacts_dict.keys():
-            contacts_list[key][layer_name] = np.array(list(contacts_dict[key]), dtype=cvd.default_int)
-
-        clusters = {layer_name: cluster_dict}
-
-    return contacts_list, layer_keys, clusters
-
-
-def make_hybrid_contacts(pop_size, ages, contacts, school_ages=None, work_ages=None):
-    '''
-    Create "hybrid" contacts -- microstructured contacts for households and
-    random contacts for schools and workplaces, both of which have extremely
-    basic age structure. A combination of both make_random_contacts() and
-    make_microstructured_contacts().
-    '''
-
-    # Handle inputs and defaults
-    layer_keys = ['h', 's', 'w', 'c']
-    contacts = sc.mergedicts({'h':4, 's':20, 'w':20, 'c':20}, contacts) # Ensure essential keys are populated
-    if school_ages is None:
-        school_ages = [6, 22]
-    if work_ages is None:
-        work_ages   = [22, 65]
-
-    # Create the empty contacts list -- a list of {'h':[], 's':[], 'w':[]}
-    contacts_list = [{key:[] for key in layer_keys} for i in range(pop_size)]
-
-    # Start with the household contacts for each person
-    h_contacts, _, clusters = make_microstructured_contacts(pop_size, {'h':contacts['h']})
-
-    # Make community contacts
-    c_contacts, _ = make_random_contacts(pop_size, {'c':contacts['c']})
-
-    # Get the indices of people in each age bin
-    ages = np.array(ages)
-    s_inds = sc.findinds((ages >= school_ages[0]) * (ages < school_ages[1]))
-    w_inds = sc.findinds((ages >= work_ages[0])   * (ages < work_ages[1]))
-
-    # Create the school and work contacts for each person
-    s_contacts, _ = make_random_contacts(len(s_inds), {'s':contacts['s']})
-    w_contacts, _ = make_random_contacts(len(w_inds), {'w':contacts['w']})
-
-    # Construct the actual lists of contacts
-    for i     in range(pop_size):   contacts_list[i]['h']   =        h_contacts[i]['h']  # Copy over household contacts -- present for everyone
-    for i,ind in enumerate(s_inds): contacts_list[ind]['s'] = s_inds[s_contacts[i]['s']] # Copy over school contacts
-    for i,ind in enumerate(w_inds): contacts_list[ind]['w'] = w_inds[w_contacts[i]['w']] # Copy over work contacts
-    for i     in range(pop_size):   contacts_list[i]['c']   =        c_contacts[i]['c']  # Copy over community contacts -- present for everyone
-
-    return contacts_list, layer_keys, clusters
-
-
-
 def make_synthpop(sim=None, population=None, layer_mapping=None, community_contacts=None, **kwargs):
     '''
     Make a population using SynthPops, including contacts. Usually called automatically,
     but can also be called manually. Either a simulation object or a population must
     be supplied; if a population is supplied, transform it into the correct format;
     otherwise, create the population and then transform it.
-
     Args:
         sim (Sim): a Covasim simulation object
         population (list): a pre-generated SynthPops population (otherwise, create a new one)
         layer_mapping (dict): a custom mapping from SynthPops layers to Covasim layers
         community_contacts (int): if a simulation is not supplied, create this many community contacts on average
         kwargs (dict): passed to sp.make_population()
-
     **Example**::
-
         sim = cv.Sim(pop_type='synthpops')
         sim.popdict = cv.make_synthpop(sim)
         sim.run()
@@ -404,3 +262,157 @@ def make_synthpop(sim=None, population=None, layer_mapping=None, community_conta
     popdict['layer_keys'] = list(layer_mapping.values())
 
     return popdict
+
+
+
+class RamdonContacts:
+    def make_random_contacts(pop_size, contacts, overshoot=1.2, dispersion=None):
+        '''
+        Make random static contacts.
+
+        Args:
+            pop_size (int): number of agents to create contacts between (N)
+            contacts (dict): a dictionary with one entry per layer describing the average number of contacts per person for that layer
+            overshoot (float): to avoid needing to take multiple Poisson draws
+            dispersion (float): if not None, use a negative binomial distribution with this dispersion parameter instead of Poisson to make the contacts
+
+        Returns:
+            contacts_list (list): a list of length N, where each entry is a dictionary by layer, and each dictionary entry is the UIDs of the agent's contacts
+            layer_keys (list): a list of layer keys, which is the same as the keys of the input "contacts" dictionary
+        '''
+
+        # Preprocessing
+        pop_size = int(pop_size) # Number of people
+        contacts = sc.dcp(contacts)
+        layer_keys = list(contacts.keys())
+        contacts_list = []
+
+        # Precalculate contacts
+        n_across_layers = np.sum(list(contacts.values()))
+        n_all_contacts  = int(pop_size*n_across_layers*overshoot) # The overshoot is used so we won't run out of contacts if the Poisson draws happen to be higher than the expected value
+        all_contacts    = cvu.choose_r(max_n=pop_size, n=n_all_contacts) # Choose people at random
+        p_counts = {}
+        for lkey in layer_keys:
+            if dispersion is None:
+                p_count = cvu.n_poisson(contacts[lkey], pop_size) # Draw the number of Poisson contacts for this person
+            else:
+                p_count = cvu.n_neg_binomial(rate=contacts[lkey], dispersion=dispersion, n=pop_size) # Or, from a negative binomial
+            p_counts[lkey] = np.array((p_count/2.0).round(), dtype=cvd.default_int)
+
+        # Make contacts
+        count = 0
+        for p in range(pop_size):
+            contact_dict = {}
+            for lkey in layer_keys:
+                n_contacts = p_counts[lkey][p]
+                contact_dict[lkey] = all_contacts[count:count+n_contacts] # Assign people
+                count += n_contacts
+            contacts_list.append(contact_dict)
+
+        return contacts_list, layer_keys
+        
+
+class MicrostructuredContacts:
+    def make_microstructured_contacts(pop_size, contacts):
+        ''' Create microstructured contacts -- i.e. for households '''
+
+        # Preprocessing -- same as above
+        pop_size = int(pop_size) # Number of people
+        contacts = sc.dcp(contacts)
+        contacts.pop('c', None) # Remove community
+        layer_keys = list(contacts.keys())
+        contacts_list = [{c:[] for c in layer_keys} for p in range(pop_size)] # Pre-populate
+
+        for layer_name, cluster_size in contacts.items():
+
+            # Initialize
+            cluster_dict = dict() # Add dictionary for this layer
+            n_remaining = pop_size # Make clusters - each person belongs to one cluster
+            contacts_dict = defaultdict(set) # Use defaultdict of sets for convenience while initializing. Could probably change this as part of performance optimization
+
+            # Loop over the clusters
+            cluster_id = -1
+            while n_remaining > 0:
+                cluster_id += 1 # Assign cluster id
+                this_cluster =  cvu.poisson(cluster_size)  # Sample the cluster size
+                if this_cluster > n_remaining:
+                    this_cluster = n_remaining
+
+                # Indices of people in this cluster
+                cluster_indices = (pop_size-n_remaining)+np.arange(this_cluster)
+                cluster_dict[cluster_id] = cluster_indices
+                for i in cluster_indices: # Add symmetric pairwise contacts in each cluster
+                    for j in cluster_indices:
+                        if j > i:
+                            contacts_dict[i].add(j)
+
+                n_remaining -= this_cluster
+
+            for key in contacts_dict.keys():
+                contacts_list[key][layer_name] = np.array(list(contacts_dict[key]), dtype=cvd.default_int)
+
+            clusters = {layer_name: cluster_dict}
+
+        return contacts_list, layer_keys, clusters
+
+class HybridContacts:
+    def make_hybrid_contacts(pop_size, ages, contacts, school_ages=None, work_ages=None):
+
+        '''
+        Create "hybrid" contacts -- microstructured contacts for households and
+        random contacts for schools and workplaces, both of which have extremely
+        basic age structure. A combination of both make_random_contacts() and
+        make_microstructured_contacts().
+        '''
+
+        # Handle inputs and defaults
+        layer_keys = ['h', 's', 'w', 'c']
+        contacts = sc.mergedicts({'h':4, 's':20, 'w':20, 'c':20}, contacts) # Ensure essential keys are populated
+        if school_ages is None:
+            school_ages = [6, 22]
+        if work_ages is None:
+            work_ages   = [22, 65]
+
+        # Create the empty contacts list -- a list of {'h':[], 's':[], 'w':[]}
+        contacts_list = [{key:[] for key in layer_keys} for i in range(pop_size)]
+
+        # Start with the household contacts for each person
+        h_contacts, _, clusters = make_microstructured_contacts(pop_size, {'h':contacts['h']})
+
+        # Make community contacts
+        c_contacts, _ = make_random_contacts(pop_size, {'c':contacts['c']})
+
+        # Get the indices of people in each age bin
+        ages = np.array(ages)
+        s_inds = sc.findinds((ages >= school_ages[0]) * (ages < school_ages[1]))
+        w_inds = sc.findinds((ages >= work_ages[0])   * (ages < work_ages[1]))
+
+        # Create the school and work contacts for each person
+        s_contacts, _ = make_random_contacts(len(s_inds), {'s':contacts['s']})
+        w_contacts, _ = make_random_contacts(len(w_inds), {'w':contacts['w']})
+
+        # Construct the actual lists of contacts
+        for i     in range(pop_size):   contacts_list[i]['h']   =        h_contacts[i]['h']  # Copy over household contacts -- present for everyone
+        for i,ind in enumerate(s_inds): contacts_list[ind]['s'] = s_inds[s_contacts[i]['s']] # Copy over school contacts
+        for i,ind in enumerate(w_inds): contacts_list[ind]['w'] = w_inds[w_contacts[i]['w']] # Copy over work contacts
+        for i     in range(pop_size):   contacts_list[i]['c']   =        c_contacts[i]['c']  # Copy over community contacts -- present for everyone
+
+        return contacts_list, layer_keys, clusters
+
+
+class ContactFactory():
+    @abstractmethod
+    def create_contacts(pop_size,ages,contacts, overshoot=1.2, dispersion=None,school_ages=None,work_ages=None):
+        pass
+
+class RamdonContactsFactory(ContactFactory):
+    def create_contacts(pop_size, contacts, overshoot=1.2, dispersion=None):
+        return RamdonContacts()
+
+class MicrostructuredContactsFactory(ContactFactory):
+    def create_contacts(pop_size,contacts):
+        return MicrostructuredContacts()
+
+class HybridContactsFactory(ContactFactory):
+    def create_contacts(pop_size, ages, contacts, school_ages=None, work_ages=None):
+        return HybridContacts()


### PR DESCRIPTION
This was part of a University Course(EECS3311- software design) project, which I applied a creational pattern to a public source project.

## What?
I've changed the layout of the population.py and applied a factory pattern on the make contacts functions. 
## Why?
The added factory classes have the responsibility of creating other contact types of objects and they can hide construction details. Each factory is atomic and enforces all invariants of the created object. Also make the code easier to read and modity later.
## How?
Give the original make contact separate classes, and add a new factory class. Then add a factory class for each type of contact.